### PR TITLE
Improvements on persist state

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -8,8 +8,10 @@ import mirror from 'mirror-folder'
 import fs from 'fs'
 import promisify from 'util-promisify'
 import { basename } from 'path'
+import { createLock } from 'flexLock'
 
 const dats = {}
+const indexLock = createLock()
 
 const stat = promisify(fs.stat)
 const readFile = promisify(fs.readFile)
@@ -249,6 +251,7 @@ export const loadFromDisk = () => async dispatch => {
 }
 
 const storeOnDisk = async () => {
+  const unlock = await indexLock()
   const dir = `${homedir()}/.dat-desktop`
   const datsState = Object.keys(dats).reduce(
     (acc, key) => ({
@@ -270,4 +273,5 @@ const storeOnDisk = async () => {
 
   await writeFile(`${dir}/dats.json`, JSON.stringify(datsState))
   await writeFile(`${dir}/paused.json`, JSON.stringify(pausedState))
+  unlock()
 }

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -278,7 +278,9 @@ const storeOnDisk = async () => {
     {}
   )
 
-  await writeFile(`${dir}/dats.json`, JSON.stringify(datsState))
-  await writeFile(`${dir}/paused.json`, JSON.stringify(pausedState))
+  await Promise.all([
+    writeFile(`${dir}/dats.json`, JSON.stringify(datsState)),
+    writeFile(`${dir}/paused.json`, JSON.stringify(pausedState))
+  ])
   unlock()
 }

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -47,7 +47,7 @@ export const addDat = ({ key, path, paused, ...opts }) => dispatch => {
     ...opts
   }
 
-  Dat(path, { key }, (error, dat) => {
+  Dat(path, { key }, async (error, dat) => {
     if (error) return dispatch({ type: 'ADD_DAT_ERROR', key, error })
     if (!key) {
       key = encode(dat.key)
@@ -144,7 +144,7 @@ export const addDat = ({ key, path, paused, ...opts }) => dispatch => {
     }, 1000)
 
     dats[key] = { dat, path, opts }
-    storeOnDisk()
+    await storeOnDisk()
   })
 }
 
@@ -177,7 +177,7 @@ const updateState = dat => {
 }
 
 export const deleteDat = key => ({ type: 'DIALOGS_DELETE_OPEN', key })
-export const confirmDeleteDat = key => dispatch => {
+export const confirmDeleteDat = key => async dispatch => {
   const { dat } = dats[key]
 
   for (const con of dat.network.connections) {
@@ -188,20 +188,20 @@ export const confirmDeleteDat = key => dispatch => {
 
   dat.close()
   delete dats[key]
-  storeOnDisk()
+  await storeOnDisk()
   dispatch({ type: 'REMOVE_DAT', key })
   dispatch({ type: 'DIALOGS_DELETE_CLOSE' })
 }
 export const cancelDeleteDat = () => ({ type: 'DIALOGS_DELETE_CLOSE' })
 
-export const togglePause = ({ key, paused }) => dispatch => {
+export const togglePause = ({ key, paused }) => async dispatch => {
   const { dat } = dats[key]
   if (paused) {
     joinNetwork(dat)(dispatch)
   } else {
     dat.leaveNetwork()
   }
-  storeOnDisk()
+  await storeOnDisk()
   if (paused) {
     dispatch({ type: 'RESUME_DAT', key: key })
   } else {

--- a/app/components/status.js
+++ b/app/components/status.js
@@ -86,7 +86,9 @@ const Status = ({ dat }) => {
   const progressbarLine =
     dat.state === 'loading'
       ? 'line-loading'
-      : dat.paused || dat.state === 'stale' ? 'line-paused' : 'line-complete'
+      : dat.paused || dat.state === 'stale' || dat.state === 'disconnected'
+        ? 'line-paused'
+        : 'line-complete'
   const netStats = dat.stats.network
 
   let progressText
@@ -108,6 +110,9 @@ const Status = ({ dat }) => {
         break
       case 'stale':
         progressText = 'waiting for peers…'
+        break
+      case 'disconnected':
+        progressText = 'waiting for connection…'
         break
       default:
         progressText = 'Paused.'

--- a/app/components/table-row.js
+++ b/app/components/table-row.js
@@ -144,7 +144,7 @@ const Row = ({ dat, shareDat, onDeleteDat, inspectDat, onTogglePause }) => (
     }}
   >
     <td className='cell-1'>
-      <div className='w2 center' onClick={() => onTogglePause(dat)}>
+      <div className='w2 center' onClick={() => onTogglePause(dat.key)}>
         <HexContent dat={dat} />
       </div>
     </td>

--- a/app/containers/table.js
+++ b/app/containers/table.js
@@ -12,7 +12,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   shareDat: link => dispatch(shareDat(link)),
   onDeleteDat: key => dispatch(deleteDat(key)),
-  onTogglePause: dat => dispatch(togglePause(dat)),
+  onTogglePause: key => dispatch(togglePause(key)),
   inspectDat: key => dispatch(inspectDat(key))
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3203,6 +3203,11 @@
       "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.6.0.tgz",
       "integrity": "sha1-/KMM3bkAb7ZW6168ea6ydOf96e0="
     },
+    "flexlock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/flexlock/-/flexlock-1.1.0.tgz",
+      "integrity": "sha512-nWanT457suFRxna8mvZwuzdKkFYKGKCx5X0QYvcIT0RlXQFUNOi+tku7VZER3tAWE4tNlTU+mmW5xSJ/MiEQrA=="
+    },
     "for-each": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dat-icons": "^2.5.1",
     "dat-node": "^3.5.6",
     "electron-default-menu": "^1.0.1",
+    "flexlock": "^1.1.0",
     "mirror-folder": "^2.1.1",
     "ms": "^2.1.1",
     "prettier-bytes": "^1.0.4",


### PR DESCRIPTION
While reviewing a few things on #500 I found a few things and i found it to be shorter to put them in pull requests than to try explain them in comments, the changes I've made:

1. Using locks for writing on disk. This way two events triggered don't run into the issue of taking assumptions of a file while writing to it.
2. Using async/await when writing to disks. Eating the error is really uncomfortable.
3. Turing async method to promises (Dat)
4. A small performance update on writing to disk.

Not sure all of this is useful but maybe it helps.