### PR TITLE
Prevent "webpacking" of native dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8386,6 +8386,12 @@
         }
       }
     },
+    "webpack-node-externals": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.6.0.tgz",
+      "integrity": "sha1-Iyxi7GCSsQBjWj0p2DwXRxKN+b0=",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "electron": "^1.7.10",
     "prettier-standard": "^8.0.0",
     "standard": "^10.0.3",
-    "webpack": "^3.10.0"
+    "webpack": "^3.10.0",
+    "webpack-node-externals": "^1.6.0"
   },
   "dependencies": {
     "dat-colors": "^3.5.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,9 @@
+const nodeExternals = require('webpack-node-externals')
+
 module.exports = {
   entry: './app/index.js',
   target: 'electron',
+  externals: [nodeExternals()],
   output: {
     filename: 'static/build.js',
     libraryTarget: 'commonjs2'


### PR DESCRIPTION
During debugging some connection issue on the react branch I found that [`utp-native`](https://github.com/mafintosh/discovery-swarm/blob/101bbc733ae696e9f7fc8aa8fe450c98b552e0a3/index.js#L16) couldn't be loaded and as a result `utp` wasn't available.

`utp` is loaded through [`node-gyp-build`](https://github.com/mafintosh/utp-native/blob/9639b375d98686c46c9f173b69da138c112454f9/index.js#L5) whichs `load`-method has a [wildcard-require](https://github.com/mafintosh/node-gyp-build/blob/8d69247eca6f6c00a1437e5093c8d281d3a4ed36/index.js#L13), resulting in following warning:

```
WARNING in ./node_modules/node-gyp-build/index.js
13:9-32 Critical dependency: the request of a dependency is an expression
    at CommonJsRequireContextDependency.getWarnings (/Users/m/Documents/dat-desktop/node_modules/webpack/lib/dependencies/ContextDependency.js:39:18)
    at Compilation.reportDependencyErrorsAndWarnings (/Users/m/Documents/dat-desktop/node_modules/webpack/lib/Compilation.js:703:24)
    at Compilation.finish (/Users/m/Documents/dat-desktop/node_modules/webpack/lib/Compilation.js:561:9)
    at applyPluginsParallel.err (/Users/m/Documents/dat-desktop/node_modules/webpack/lib/Compiler.js:502:17)
    at /Users/m/Documents/dat-desktop/node_modules/tapable/lib/Tapable.js:289:11
    at _addModuleChain (/Users/m/Documents/dat-desktop/node_modules/webpack/lib/Compilation.js:507:11)
    at processModuleDependencies.err (/Users/m/Documents/dat-desktop/node_modules/webpack/lib/Compilation.js:477:14)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

This means that as-is webpack can not find the depending packages. This PR marks all node-modules as external, which puts it in a similar build structure as is currently used by the choo-builds and thus allows access to `utp-native`.