### PR TITLE
React Viewer: Streaming API (and other tweaks)

### DIFF
--- a/app/components/viewer/index.js
+++ b/app/components/viewer/index.js
@@ -1,33 +1,82 @@
 import React from 'react'
 import Dialog from '../dialog'
+import url from 'url'
+
+const streams = {}
 
 const Viewer = ({ show, dat, path, onExit }) => {
+  const datPath = `dat://${dat && dat.key.toString('hex')}/${path}#${dat && dat.version}`
+  const initFile = (datPath, cb) => {
+    const parts = url.parse(datPath)
+    // TODO: version is not considered ...
+    if (parts.hostname !== dat.key.toString('hex')) return cb(new Error('Dat already closed'))
+    dat.archive.stat(parts.path, cb)
+  }
+  const readFile = (datPath, start, end, cb) => {
+    const parts = url.parse(datPath)
+    // TODO: version is not considered ...
+    if (parts.hostname !== dat.key.toString('hex')) return cb(new Error('Dat already closed'))
+
+    // TODO: multiple reads on the same file should not open/close the file
+    dat.archive.open(path, 'r', (err, fd) => {
+      if (err) return cb(err)
+
+      const buf = Buffer.alloc(end - start)
+      dat.archive.read(fd, buf, 0, buf.length, start, err => err ? cb(err) : cb(null, buf))
+    })
+  }
   const onref = webview => {
     webview.addEventListener('ipc-message', ev => {
-      if (ev.channel !== 'req') return
-      const { cmd, args, id } = ev.args[0]
+      if (ev.channel === 'viewer:init') {
+        webview.send('viewer:open', datPath)
+        return
+      }
+      if (ev.channel === 'viewer:stream') {
+        const {cmd, id, datPath, start, end} = ev.args[0]
+        if (cmd === 'open') {
+          const parts = url.parse(datPath)
+          // TODO: version is not considered ...
+          if (parts.hostname !== dat.key.toString('hex')) return webview.send('viewer:stream', id, new Error('Dat already closed'))
 
-      if (cmd === 'read') {
-        const [start, end] = args
-        dat.archive.open(path, 'r', (err, fd) => {
-          if (err) return webview.send('res', id, err.message)
-
-          const buf = Buffer.alloc(end - start)
-          dat.archive.read(fd, buf, 0, end - start, start, err => {
-            if (err) return webview.send('res', id, err.message)
-
-            webview.send('res', id, null, buf.toString('hex'))
+          const stream = dat.archive.createReadStream(parts.path, {start, end})
+          stream.on('data', data => webview.send('viewer:stream', id, null, data.toString()))
+          stream.on('error', error => webview.send('viewer:stream', id, error))
+          stream.on('end', data => {
+            delete streams[id]
+            webview.send('viewer:stream', id, null, null)
           })
-        })
-      } else if (cmd === 'size') {
-        dat.archive.stat(path, (err, stat) => {
-          if (err) return webview.send('res', id, err.message)
-          webview.send('res', id, null, stat.size)
-        })
+          streams[id] = stream
+        }
+        if (cmd === 'close') {
+          const stream = streams[id]
+          if (stream) stream.close()
+        }
+        return
+      }
+      if (ev.channel === 'viewer:exec') {
+        const {cmd, id, args} = ev.args[0]
+        const cb = (err, data) => {
+          webview.send('viewer:exec', id, err, data)
+        }
+        if (cmd === 'init') {
+          const [datPath] = args
+          initFile(datPath, cb)
+        } else if (cmd === 'read') {
+          const [datPath, start, end] = args
+          readFile(datPath, start, end, cb)
+        }
       }
     })
     webview.addEventListener('console-message', e => {
-      console.log(e.message)
+      var srcFile = e.sourceId.replace(/^.*[\\/]/, '')
+      const msg = `[webview@${srcFile}(${e.line})]: ${e.message}`
+      if (e.level === 2) {
+        console.error(msg)
+      } else if (e.level === 1) {
+        console.warn(msg)
+      } else {
+        console.log(msg)
+      }
     })
   }
   return (

--- a/app/components/viewer/preload.js
+++ b/app/components/viewer/preload.js
@@ -1,21 +1,261 @@
 const { ipcRenderer } = require('electron')
 
-const callbacks = []
+let currentId = 0.0
 
-window.read = (start, end, cb) =>
-  send('read', [start, end], (err, str) => {
-    if (err) return cb(err)
-    cb(null, Buffer.from(str, 'hex'))
-  })
-window.size = cb => send('size', [], cb)
+/*
+;['log', 'warn', 'error', 'info'].forEach(function (prop) {
+  const old = console[prop]
+  console[prop] = function () {
+    let arg = arguments[0]
+    if (arguments.length > 1) {
+      arg = Array.from(arguments).join(' ')
+    }
+    old.call(console, arg)
+  }
+})
+*/
 
-const send = (cmd, args, cb) => {
-  const id = callbacks.length
-  callbacks.push({ id, cb })
-  ipcRenderer.sendToHost('req', { cmd, args, id })
+function nextId () {
+  currentId += 1.0
+  return currentId
 }
 
-ipcRenderer.on('res', (_, id, err, ...args) => {
-  const cb = callbacks.find(o => o.id === id).cb
-  cb(err, ...args)
+function validateRange (file, start, end) {
+  return file.size()
+    .then(size => {
+      if (start === undefined || start === null) {
+        start = 0
+      }
+      if (end === undefined || end === null) {
+        end = size
+      }
+      if (start > size) {
+        throw new Error(`Can not create stream for ${file.datPath}[${start}:${end}] because start is out of bounds ${size}`)
+      }
+      if (end > size) {
+        throw new Error(`Can not create stream for ${file.datPath}[${start}:${end}] because end is out of bounds ${size}`)
+      }
+      if (start > end) {
+        throw new Error(`Can not create stream for ${file.datPath}[${start}:${end}] because start is after end`)
+      }
+      return {start, end}
+    })
+}
+
+class EventEmitter {
+  constructor () {
+    this.removeAllListeners()
+  }
+  removeAllListeners () {
+    this.handlers = {}
+  }
+  removeListener (event, handler) {
+    const handlers = this.handlers[event]
+    if (handlers === null || handlers === undefined) return
+    if (handlers === handler) {
+      delete this.handlers[event]
+      return
+    }
+    if (Array.isArray(handlers)) {
+      handlers.splice(handlers.findIndex(h => h === handler), 1)
+      if (handlers.length === 1) {
+        this.handlers[event] = handlers[0]
+      }
+    }
+  }
+  emit (event, ...args) {
+    const handlers = this.handlers[event]
+    // No handler
+    if (handlers === null || handlers === undefined) return
+    if (Array.isArray(handlers)) {
+      // many handlers
+      handlers.forEach(handler => handler(...args))
+      return
+    }
+    // One handler
+    handlers(...args)
+  }
+  on (event, handler) {
+    let handlers = this.handlers[event]
+    if (handlers === undefined) {
+      throw new Error(`Event ${event} not supported! (Supported events: ${Object.keys(this.handlers)})`)
+    }
+    if (Array.isArray(handlers)) {
+      handlers.push(handler)
+      return
+    }
+    if (handlers !== null) {
+      handlers = [handlers, handler]
+    } else {
+      handlers = handler
+    }
+    this.handlers[event] = handlers
+  }
+}
+
+class Stream extends EventEmitter {
+  constructor (file, start, end) {
+    super()
+    this.id = nextId()
+    this.file = file
+    this.start = start
+    this.end = end
+    this.removeAllListeners()
+    validateRange(file, start, end)
+      .then(({start, end}) =>
+        ipcRenderer.sendToHost('viewer:stream', {
+          cmd: 'open',
+          start,
+          end,
+          id: this.id,
+          datPath: file.datPath
+        })
+      )
+      .catch(err => {
+        console.warn(err)
+        this.close(err)
+      })
+  }
+  write (err, data) {
+    if (this.closed) return
+    if (err) {
+      // marking it closed before emitting error!
+      this.closed = true
+      this.emit('error', err)
+      // making sure that data is null!
+      data = null
+    }
+    if (data === null) {
+      this.closed = true
+      this.emit('end')
+      this.removeAllListeners()
+    } else {
+      this.emit('data', data)
+    }
+  }
+  removeAllListeners () {
+    this.handlers = {
+      data: null,
+      end: null,
+      error: null
+    }
+  }
+  close (err) {
+    if (this.closed) return
+    this.closed = true
+    if (err) {
+      this.emit('error', err)
+    }
+    this.emit('end')
+    ipcRenderer.sendToHost('viewer:stream', {cmd: 'close', id: this.id})
+    this.removeAllListeners()
+  }
+}
+
+class File {
+  constructor (datPath) {
+    this.datPath = datPath
+    this._streams = {}
+    this._execs = {}
+    this._stats = this.exec('init', this.datPath)
+    this._size = this._stats.then(data => {
+      return data.size
+    })
+  }
+  exec (cmd, ...args) {
+    if (this.destroyed) return
+    const promise = exec({cmd, args})
+    this._execs[promise.id] = true
+    return promise
+      .catch(err => {
+        if (!this.destroyed) {
+          delete this._execs[promise.id]
+        }
+        return Promise.reject(err)
+      })
+      .then((data) => {
+        if (this.destroyed) return
+        delete this._execs[promise.id]
+        return data
+      })
+  }
+  stats () {
+    return this._stats
+  }
+  size () {
+    return this._size
+  }
+  destroy () {
+    if (this.destroyed) return
+    this.destroyed = true
+    Object.values(this._streams).forEach(stream => stream.close())
+    this._streams = null
+    Object.keys(this._execs).forEach(cancelExec)
+    this._execs = null
+  }
+  read (start, end) {
+    return validateRange(this, start, end)
+      .then(({start, end}) => this.exec('read', this.datPath, start, end))
+  }
+  createReadStream (start, end) {
+    const stream = createStream(this, start, end)
+    this._streams[stream.id] = stream
+    stream.on('end', () => {
+      delete this._streams[stream.id]
+    })
+    return stream
+  }
+}
+
+window.openFile = (datPath) => {
+  return new File(datPath)
+}
+window.initViewer = () => {
+  ipcRenderer.sendToHost('viewer:init')
+}
+
+const _cbs = {}
+function cancelExec (id) {
+  delete _cbs[id]
+}
+
+function exec (opts) {
+  let cb
+  const promise = new Promise((resolve, reject) => {
+    cb = (err, data) => err ? reject(err) : resolve(data)
+  })
+  const id = nextId()
+  promise.id = id
+  opts.id = id
+  _cbs[id] = cb
+  ipcRenderer.sendToHost('viewer:exec', opts)
+  return promise
+}
+
+const _streams = {}
+
+function createStream (file, start, end) {
+  const stream = new Stream(file, start, end)
+  _streams[stream.id] = stream
+  stream.on('end', () => delete _streams[stream.id])
+  return stream
+}
+
+ipcRenderer.on('viewer:exec', function (_, id, error, data) {
+  const cb = _cbs[id]
+  if (!cb) return
+  delete _cbs[id]
+  cb(error, data)
+})
+
+ipcRenderer.on('viewer:stream', function (_, id, error, data) {
+  const stream = _streams[id]
+  if (!stream) return
+  stream.write(error, data)
+})
+
+ipcRenderer.on('viewer:open', function (_, datPath) {
+  var event = new window.Event('viewer:open')
+  event.file = datPath
+  window.dispatchEvent(event)
 })

--- a/app/viewers/text/index.js
+++ b/app/viewers/text/index.js
@@ -2,10 +2,31 @@ const pre = document.createElement('pre')
 pre.innerText = 'loading...'
 document.body.appendChild(pre)
 
-window.size((err, size) => {
-  if (err) throw err
-  window.read(0, size, (err, buf) => {
-    if (err) throw err
-    pre.innerText = buf.toString()
+let current
+let firstData
+
+window.addEventListener('viewer:open', async (event) => {
+  if (current) {
+    current.destroy()
+  }
+  const file = event.file
+  current = window.openFile(file)
+  current.read(20, 60).then(data => {
+    console.log('random bytes: ' + data)
+  })
+  pre.innerText = 'loading...'
+  firstData = true
+  const stream = current.createReadStream()
+  stream.on('data', (buffer, enc) => {
+    if (firstData) {
+      pre.innerText = ''
+      firstData = false
+    }
+    pre.innerText += buffer
+  })
+  stream.on('end', () => {
+    console.log('completely read.')
   })
 })
+
+window.initViewer()


### PR DESCRIPTION
Looking over #515 I wondered how a different API could look like that more future proof to our case. I came up with the API in this PR. Essentially it adds following things:

1. It adds a very simple streaming implementation - in case one just wants to stream the whole file
2. It adds a `initViewer` command to init one viewer; subsequently `viewer:open` events are called which each should be triggered when someone opens the webview - this way the viewer can theoretically be reused in future iterations instead of respawned for each file
3. It uses dat links with versions as file reference which should make sure that the preview always loads the correct data from the correct dat archive. Aside from this helping debugging, it should help to figure out timing problems in the user interface once we implement versions and rapid navigation in the files.
4. It adds a few improvements to error handling (now we get file number and log type for events in the viewer