### PR TITLE
Removed temporary link in the import-dat ui element.

### DIFF
--- a/app/components/dat-import.js
+++ b/app/components/dat-import.js
@@ -70,7 +70,6 @@ const DatImport = ({ onAddDat }) => {
         placeholder='Download'
         onKeyDown={onKeyDown}
         className='input-reset f7 f6-l'
-        defaultValue='dat://40a7f6b6147ae695bcbcff432f684c7bb5291ea339c28c1755896cdeb80bd2f9/'
       />
       <Icon name='link' className='absolute top-0 bottom-0 left-0' />
     </Label>


### PR DESCRIPTION
In the react branch we have a temporary link on the Import-Dat UI element, this PR removes it in preparation for the react release.