### PR TITLE
Extracted actions into middleware

### DIFF
--- a/app/actions/dat-middleware.js
+++ b/app/actions/dat-middleware.js
@@ -1,0 +1,380 @@
+'use strict'
+
+import Dat from 'dat-node'
+import { encode } from 'dat-encoding'
+import { homedir } from 'os'
+import fs from 'fs'
+import { basename } from 'path'
+import { ipcRenderer, shell } from 'electron'
+import mirror from 'mirror-folder'
+import promisify from 'util-promisify'
+
+const readFile = promisify(fs.readFile)
+const writeFile = promisify(fs.writeFile)
+const mkdir = promisify(fs.mkdir)
+const { Notification } = window
+
+export default class DatMiddleware {
+  constructor () {
+    this.dats = {}
+    this.listeners = []
+    this.execByType = {
+      UPDATE_TITLE: action => this.updateTitle(action),
+      REMOVE_DAT: action => this.removeDat(action),
+      TRY_ADD_DAT: action => this.tryAddDat(action),
+      TOGGLE_PAUSE: action => this.togglePause(action),
+      DOWNLOAD_SPARSE_DAT: action => this.downloadSparseDat(action),
+      CANCEL_DOWNLOAD_DAT: action => this.cancelDownloadDat(action)
+    }
+  }
+
+  execAction (action) {
+    const exec = this.execByType[action.type]
+    if (!exec) return false
+    // Telling it to all the middlewares.
+    this.dispatch(action)
+    exec(action)
+      .then(data =>
+        this.dispatch({ ...action, type: `${action.type}_SUCCESS`, ...data })
+      )
+      .catch(error =>
+        this.dispatch({ ...action, type: `${action.type}_ERROR`, error })
+      )
+    return true
+  }
+
+  middleware (store) {
+    return dispatch => {
+      this.listeners.push(dispatch)
+      return action => {
+        const triggersEffect = this.execAction(action)
+        if (!triggersEffect) {
+          // This action was not ment for this middleware.
+          // Pass on to the next.
+          dispatch(action)
+        }
+      }
+    }
+  }
+
+  dispatch (action) {
+    this.listeners.forEach(listener => listener(action))
+  }
+
+  async updateTitle ({ path, editValue }) {
+    const filePath = `${path}/dat.json`
+    const blob = await readFile(filePath)
+    const metadata = { ...JSON.parse(blob), title: editValue }
+    await writeFile(filePath, JSON.stringify(metadata))
+  }
+
+  async removeDat ({ key }) {
+    const { dat } = this.dats[key]
+
+    if (dat.network) {
+      for (const con of dat.network.connections) {
+        con.removeAllListeners()
+      }
+    }
+    dat.stats.removeAllListeners()
+    clearInterval(dat.updateInterval)
+
+    dat.close()
+    delete this.dats[key]
+    this.storeOnDisk()
+  }
+
+  async tryAddDat ({ key, path, paused, ...opts }) {
+    if (key) key = encode(key)
+    if (!path) path = `${homedir()}/Downloads/${key}`
+
+    if (key) this.dispatch({ type: 'ADD_DAT', key, path, paused })
+    opts = {
+      watch: true,
+      resume: true,
+      ignoreHidden: true,
+      compareFileContent: true,
+      ...opts
+    }
+
+    Dat(path, { key }, (error, dat) => {
+      if (error) return this.dispatch({ type: 'ADD_DAT_ERROR', key, error })
+      if (!key) {
+        key = encode(dat.key)
+        this.dispatch({ type: 'ADD_DAT', key, path, paused })
+      }
+
+      dat.trackStats()
+      if (dat.writable) dat.importFiles(opts)
+
+      this.dispatch({
+        type: 'DAT_METADATA',
+        key,
+        metadata: {
+          title: basename(path),
+          author: 'Anonymous'
+        }
+      })
+
+      this.dispatch({ type: 'ADD_DAT_SUCCESS', key })
+      this.dispatch({ type: 'DAT_WRITABLE', key, writable: dat.writable })
+
+      dat.archive.readFile('/dat.json', (err, blob) => {
+        if (err) return
+
+        let metadata = {}
+        try {
+          metadata = JSON.parse(blob)
+        } catch (_) {}
+
+        this.dispatch({ type: 'DAT_METADATA', key, metadata })
+      })
+
+      if (dat.archive.content) this.walk(dat)
+      else dat.archive.on('content', () => this.walk(dat))
+
+      dat.stats.on('update', stats => {
+        if (!stats) stats = dat.stats.get()
+        this.updateProgress(dat, key, stats)
+        this.dispatch({ type: 'DAT_STATS', key, stats: { ...stats } })
+      })
+
+      this.updateState(dat)
+      this.updateProgress(dat, key)
+
+      if (!paused) {
+        this.joinNetwork(dat)
+        this.updateConnections(dat)
+      }
+
+      let prevNetworkStats
+      dat.updateInterval = setInterval(() => {
+        const stats = JSON.stringify(dat.stats.network)
+        if (stats === prevNetworkStats) return
+        prevNetworkStats = stats
+        this.dispatch({
+          type: 'DAT_NETWORK_STATS',
+          key,
+          stats: {
+            up: dat.stats.network.uploadSpeed,
+            down: dat.stats.network.downloadSpeed
+          }
+        })
+      }, 1000)
+
+      this.dats[key] = { dat, path, opts }
+      this.storeOnDisk()
+    })
+  }
+
+  updateProgress (dat, key, stats) {
+    if (!stats) stats = dat.stats.get()
+    const prevProgress = dat.progress
+    const progress = !dat.stats
+      ? 0
+      : dat.writable ? 1 : Math.min(1, stats.downloaded / stats.length)
+    dat.progress = progress
+
+    this.dispatch({ type: 'DAT_PROGRESS', key, progress })
+    this.updateState(dat)
+
+    const unfinishedBefore = prevProgress < 1 && prevProgress > 0
+    if (dat.progress === 1 && unfinishedBefore) {
+      const notification = new Notification('Download finished', {
+        body: key
+      })
+      notification.onclick = () =>
+        shell.openExternal(`file://${dat.path}`, () => {})
+    }
+
+    const incomplete = []
+    for (const d of Object.values(this.dats)) {
+      if (d.network && d.progress < 1) incomplete.push(d)
+    }
+    let totalProgress = incomplete.length
+      ? incomplete.reduce((acc, dat) => {
+        return acc + dat.progress
+      }, 0) / incomplete.length
+      : 1
+    if (totalProgress === 1) totalProgress = -1 // deactivate
+    if (ipcRenderer) ipcRenderer.send('progress', totalProgress)
+  }
+
+  async togglePause ({ key, paused }) {
+    const { dat } = this.dats[key]
+    if (paused) {
+      this.joinNetwork(dat)
+    } else {
+      dat.leaveNetwork()
+    }
+    this.storeOnDisk()
+  }
+
+  async downloadSparseDat ({ key }) {
+    key = encode(key)
+    const path = `${homedir()}/Downloads/${key}`
+
+    this.dispatch({ type: 'ADD_DAT', key, path })
+
+    Dat(path, { key, sparse: true }, (error, dat) => {
+      if (error) return this.dispatch({ type: 'ADD_DAT_ERROR', key, error })
+
+      dat.trackStats()
+
+      this.dispatch({
+        type: 'DAT_METADATA',
+        key,
+        metadata: {
+          title: basename(path),
+          author: 'Anonymous'
+        }
+      })
+
+      this.dispatch({ type: 'ADD_DAT_SUCCESS', key })
+
+      dat.archive.readFile('/dat.json', (err, blob) => {
+        if (err) return
+
+        let metadata = {}
+        try {
+          metadata = JSON.parse(blob)
+        } catch (_) {}
+
+        this.dispatch({ type: 'DAT_METADATA', key, metadata })
+      })
+
+      if (dat.archive.content) this.walk(dat)
+      else dat.archive.on('content', () => this.walk(dat))
+
+      dat.stats.on('update', stats => {
+        if (!stats) stats = dat.stats.get()
+        this.dispatch({ type: 'DAT_STATS', key, stats: { ...stats } })
+      })
+
+      this.updateState(dat)
+      this.joinNetwork(dat)
+      this.updateConnections(dat)
+
+      this.dats[key] = { dat, path }
+    })
+  }
+
+  async cancelDownloadDat (key) {
+    key = encode(key)
+    const { dat } = this.dats[key]
+
+    for (const con of dat.network.connections) {
+      con.removeAllListeners()
+    }
+    dat.stats.removeAllListeners()
+    clearInterval(dat.updateInterval)
+
+    dat.close()
+    delete this.dats[key]
+    this.dispatch({ type: 'REMOVE_DAT', key })
+  }
+
+  walk (dat) {
+    const key = encode(dat.key)
+    if (!dat.files) dat.files = []
+    var fs = { name: '/', fs: dat.archive }
+    var progress = mirror(fs, '/', { dryRun: true })
+    progress.on('put', file => {
+      file.name = file.name.slice(1)
+      if (file.name === '') return
+      dat.files.push({
+        path: file.name,
+        size: file.stat.size,
+        isFile: file.stat.isFile()
+      })
+      dat.files.sort(function (a, b) {
+        return a.path.localeCompare(b.path)
+      })
+
+      const { files } = dat
+      this.dispatch({ type: 'DAT_FILES', key, files })
+    })
+  }
+
+  updateState (dat) {
+    const key = encode(dat.key)
+    const state = !dat.network
+      ? 'paused'
+      : dat.writable || dat.progress === 1
+        ? 'complete'
+        : dat.network.connected ? 'loading' : 'stale'
+    this.dispatch({ type: 'DAT_STATE', key, state })
+  }
+
+  updateConnections (dat) {
+    if (!dat.network) return
+    const key = encode(dat.key)
+    this.dispatch({ type: 'DAT_PEERS', key, peers: dat.network.connected })
+  }
+
+  joinNetwork (dat) {
+    dat.joinNetwork()
+    dat.network.on('connection', con => {
+      this.updateConnections(dat)
+      this.updateState(dat)
+      con.on('close', () => {
+        this.updateConnections(dat)
+        this.updateState(dat)
+      })
+    })
+  }
+
+  async loadFromDisk () {
+    try {
+      await mkdir(`${homedir()}/.dat-desktop`)
+    } catch (_) {}
+
+    let blob
+    try {
+      blob = await readFile(`${homedir()}/.dat-desktop/dats.json`, 'utf8')
+    } catch (_) {
+      return
+    }
+    const datOpts = JSON.parse(blob)
+
+    blob = {}
+    try {
+      blob = await readFile(`${homedir()}/.dat-desktop/paused.json`, 'utf8')
+    } catch (_) {}
+    const paused = JSON.parse(blob)
+
+    for (const key of Object.keys(datOpts)) {
+      const opts = JSON.parse(datOpts[key])
+      this.tryAddDat({
+        key,
+        path: opts.dir,
+        paused: paused[key],
+        ...opts
+      })
+    }
+  }
+
+  async storeOnDisk () {
+    const dir = `${homedir()}/.dat-desktop`
+    const datsState = Object.keys(this.dats).reduce(
+      (acc, key) => ({
+        ...acc,
+        [key]: JSON.stringify({
+          dir: this.dats[key].path,
+          opts: this.dats[key].opts
+        })
+      }),
+      {}
+    )
+    const pausedState = Object.keys(this.dats).reduce(
+      (acc, key) => ({
+        ...acc,
+        [key]: !this.dats[key].dat.network
+      }),
+      {}
+    )
+
+    await writeFile(`${dir}/dats.json`, JSON.stringify(datsState))
+    await writeFile(`${dir}/paused.json`, JSON.stringify(pausedState))
+  }
+}

--- a/app/actions/dat-middleware.js
+++ b/app/actions/dat-middleware.js
@@ -4,14 +4,14 @@ import Dat from 'dat-node'
 import { encode } from 'dat-encoding'
 import { homedir } from 'os'
 import fs from 'fs'
-import { basename } from 'path'
+import { basename, join as joinPath } from 'path'
 import { ipcRenderer, shell } from 'electron'
+import mkdirp from 'mkdirp-promise'
 import mirror from 'mirror-folder'
 import promisify from 'util-promisify'
 
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
-const mkdir = promisify(fs.mkdir)
 const { Notification } = window
 
 export default class DatMiddleware {
@@ -326,12 +326,15 @@ export default class DatMiddleware {
 
   async loadFromDisk () {
     try {
-      await mkdir(`${homedir()}/.dat-desktop`)
+      await mkdirp(joinPath(homedir(), '.dat-desktop'))
     } catch (_) {}
 
     let blob
     try {
-      blob = await readFile(`${homedir()}/.dat-desktop/dats.json`, 'utf8')
+      blob = await readFile(
+        joinPath(homedir(), '.dat-desktop', 'dats.json'),
+        'utf8'
+      )
     } catch (_) {
       return
     }
@@ -339,7 +342,10 @@ export default class DatMiddleware {
 
     blob = {}
     try {
-      blob = await readFile(`${homedir()}/.dat-desktop/paused.json`, 'utf8')
+      blob = await readFile(
+        joinPath(homedir(), '.dat-desktop', 'paused.json'),
+        'utf8'
+      )
     } catch (_) {}
     const paused = JSON.parse(blob)
 
@@ -356,6 +362,9 @@ export default class DatMiddleware {
 
   async storeOnDisk () {
     const dir = `${homedir()}/.dat-desktop`
+    try {
+      await mkdirp(dir)
+    } catch (_) {}
     const datsState = Object.keys(this.dats).reduce(
       (acc, key) => ({
         ...acc,
@@ -374,7 +383,7 @@ export default class DatMiddleware {
       {}
     )
 
-    await writeFile(`${dir}/dats.json`, JSON.stringify(datsState))
-    await writeFile(`${dir}/paused.json`, JSON.stringify(pausedState))
+    await writeFile(joinPath(dir, 'dats.json'), JSON.stringify(datsState))
+    await writeFile(joinPath(dir, 'paused.json'), JSON.stringify(pausedState))
   }
 }

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -45,7 +45,7 @@ export const addDat = ({ key, path, paused, ...opts }) => dispatch =>
   dispatch({ type: 'TRY_ADD_DAT', key, path, paused, ...opts })
 export const deleteDat = key => ({ type: 'DIALOGS_DELETE_OPEN', key })
 export const confirmDeleteDat = key => dispatch => {
-  dispatch({ type: 'REMOVE_DAT' })
+  dispatch({ type: 'REMOVE_DAT', key })
   dispatch({ type: 'DIALOGS_DELETE_CLOSE' })
 }
 export const cancelDeleteDat = () => ({ type: 'DIALOGS_DELETE_CLOSE' })

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -1,21 +1,11 @@
 'use strict'
 
-import Dat from 'dat-node'
 import { encode } from 'dat-encoding'
-import { homedir } from 'os'
-import { clipboard, remote, ipcRenderer, shell } from 'electron'
-import mirror from 'mirror-folder'
+import { clipboard, remote, shell } from 'electron'
 import fs from 'fs'
 import promisify from 'util-promisify'
-import { basename } from 'path'
-
-const dats = {}
 
 const stat = promisify(fs.stat)
-const readFile = promisify(fs.readFile)
-const writeFile = promisify(fs.writeFile)
-const mkdir = promisify(fs.mkdir)
-const { Notification } = window
 
 export const shareDat = key => ({ type: 'DIALOGS_LINK_OPEN', key })
 export const copyLink = link => {
@@ -38,21 +28,8 @@ export const showDownloadScreen = key => ({
   key: encode(key)
 })
 export const hideDownloadScreen = () => ({ type: 'HIDE_DOWNLOAD_SCREEN' })
-export const cancelDownloadDat = key => dispatch => {
-  key = encode(key)
-  const { dat } = dats[key]
-
-  for (const con of dat.network.connections) {
-    con.removeAllListeners()
-  }
-  dat.stats.removeAllListeners()
-  clearInterval(dat.updateInterval)
-
-  dat.close()
-  delete dats[key]
-  dispatch({ type: 'REMOVE_DAT', key })
-}
-
+export const cancelDownloadDat = key => dispatch =>
+  dispatch({ type: 'CANCEL_DOWNLOAD_DAT', key })
 export const changeDownloadPath = key => dispatch => {
   const files = remote.dialog.showOpenDialog({
     properties: ['openDirectory']
@@ -62,255 +39,18 @@ export const changeDownloadPath = key => dispatch => {
   dispatch({ type: 'CHANGE_DOWNLOAD_PATH', key, path })
 }
 
-const walk = dat => dispatch => {
-  const key = encode(dat.key)
-  if (!dat.files) dat.files = []
-  var fs = { name: '/', fs: dat.archive }
-  var progress = mirror(fs, '/', { dryRun: true })
-  progress.on('put', function (file) {
-    file.name = file.name.slice(1)
-    if (file.name === '') return
-    dat.files.push({
-      path: file.name,
-      size: file.stat.size,
-      isFile: file.stat.isFile()
-    })
-    dat.files.sort(function (a, b) {
-      return a.path.localeCompare(b.path)
-    })
-
-    const { files } = dat
-    dispatch({ type: 'DAT_FILES', key, files })
-  })
-}
-
-export const downloadSparseDat = ({ key }) => dispatch => {
-  key = encode(key)
-  const path = `${homedir()}/Downloads/${key}`
-
-  dispatch({ type: 'ADD_DAT', key, path })
-
-  Dat(path, { key, sparse: true }, (error, dat) => {
-    if (error) return dispatch({ type: 'ADD_DAT_ERROR', key, error })
-
-    dat.trackStats()
-
-    dispatch({
-      type: 'DAT_METADATA',
-      key,
-      metadata: {
-        title: basename(path),
-        author: 'Anonymous'
-      }
-    })
-
-    dispatch({ type: 'ADD_DAT_SUCCESS', key })
-
-    dat.archive.readFile('/dat.json', (err, blob) => {
-      if (err) return
-
-      let metadata = {}
-      try {
-        metadata = JSON.parse(blob)
-      } catch (_) {}
-
-      dispatch({ type: 'DAT_METADATA', key, metadata })
-    })
-
-    if (dat.archive.content) walk(dat)(dispatch)
-    else dat.archive.on('content', () => walk(dat)(dispatch))
-
-    dat.stats.on('update', stats => {
-      if (!stats) stats = dat.stats.get()
-      dispatch({ type: 'DAT_STATS', key, stats: { ...stats } })
-    })
-
-    dispatch(updateState(dat))
-    joinNetwork(dat)(dispatch)
-    updateConnections(dat)(dispatch)
-
-    dats[key] = { dat, path }
-  })
-}
-
-export const addDat = ({ key, path, paused, ...opts }) => dispatch => {
-  if (key) key = encode(key)
-  if (!path) path = `${homedir()}/Downloads/${key}`
-
-  if (key) dispatch({ type: 'ADD_DAT', key, path, paused })
-  opts = {
-    watch: true,
-    resume: true,
-    ignoreHidden: true,
-    compareFileContent: true,
-    ...opts
-  }
-
-  Dat(path, { key }, (error, dat) => {
-    if (error) return dispatch({ type: 'ADD_DAT_ERROR', key, error })
-    if (!key) {
-      key = encode(dat.key)
-      dispatch({ type: 'ADD_DAT', key, path, paused })
-    }
-
-    dat.trackStats()
-    if (dat.writable) dat.importFiles(opts)
-
-    dispatch({
-      type: 'DAT_METADATA',
-      key,
-      metadata: {
-        title: basename(path),
-        author: 'Anonymous'
-      }
-    })
-
-    dispatch({ type: 'ADD_DAT_SUCCESS', key })
-    dispatch({ type: 'DAT_WRITABLE', key, writable: dat.writable })
-
-    dat.archive.readFile('/dat.json', (err, blob) => {
-      if (err) return
-
-      let metadata = {}
-      try {
-        metadata = JSON.parse(blob)
-      } catch (_) {}
-
-      dispatch({ type: 'DAT_METADATA', key, metadata })
-    })
-
-    if (dat.archive.content) walk(dat)(dispatch)
-    else dat.archive.on('content', () => walk(dat)(dispatch))
-
-    dat.stats.on('update', stats => {
-      if (!stats) stats = dat.stats.get()
-      updateProgress(stats)
-      dispatch({ type: 'DAT_STATS', key, stats: { ...stats } })
-    })
-
-    dispatch(updateState(dat))
-
-    const updateProgress = stats => {
-      if (!stats) stats = dat.stats.get()
-      const prevProgress = dat.progress
-      const progress = !dat.stats
-        ? 0
-        : dat.writable ? 1 : Math.min(1, stats.downloaded / stats.length)
-      dat.progress = progress
-
-      dispatch({ type: 'DAT_PROGRESS', key, progress })
-      dispatch(updateState(dat))
-
-      const unfinishedBefore = prevProgress < 1 && prevProgress > 0
-      if (dat.progress === 1 && unfinishedBefore) {
-        const notification = new Notification('Download finished', {
-          body: key
-        })
-        notification.onclick = () =>
-          shell.openExternal(`file://${dat.path}`, () => {})
-      }
-
-      const incomplete = []
-      for (const d of Object.values(dats)) {
-        if (d.network && d.progress < 1) incomplete.push(d)
-      }
-      let totalProgress = incomplete.length
-        ? incomplete.reduce((acc, dat) => {
-          return acc + dat.progress
-        }, 0) / incomplete.length
-        : 1
-      if (totalProgress === 1) totalProgress = -1 // deactivate
-      if (ipcRenderer) ipcRenderer.send('progress', totalProgress)
-    }
-    updateProgress()
-
-    if (!paused) {
-      joinNetwork(dat)(dispatch)
-      updateConnections(dat)(dispatch)
-    }
-
-    let prevNetworkStats
-    dat.updateInterval = setInterval(() => {
-      const stats = JSON.stringify(dat.stats.network)
-      if (stats === prevNetworkStats) return
-      prevNetworkStats = stats
-      dispatch({
-        type: 'DAT_NETWORK_STATS',
-        key,
-        stats: {
-          up: dat.stats.network.uploadSpeed,
-          down: dat.stats.network.downloadSpeed
-        }
-      })
-    }, 1000)
-
-    dats[key] = { dat, path, opts }
-    storeOnDisk()
-  })
-}
-
-const joinNetwork = dat => dispatch => {
-  dat.joinNetwork()
-  dat.network.on('connection', con => {
-    updateConnections(dat)(dispatch)
-    dispatch(updateState(dat))
-    con.on('close', () => {
-      updateConnections(dat)(dispatch)
-      dispatch(updateState(dat))
-    })
-  })
-}
-
-const updateConnections = dat => dispatch => {
-  if (!dat.network) return
-  const key = encode(dat.key)
-  dispatch({ type: 'DAT_PEERS', key, peers: dat.network.connected })
-}
-
-const updateState = dat => {
-  const key = encode(dat.key)
-  const state = !dat.network
-    ? 'paused'
-    : dat.writable || dat.progress === 1
-      ? 'complete'
-      : dat.network.connected ? 'loading' : 'stale'
-  return { type: 'DAT_STATE', key, state }
-}
-
+export const downloadSparseDat = ({ key }) => dispatch =>
+  dispatch({ type: 'DOWNLOAD_SPARSE_DAT', key })
+export const addDat = ({ key, path, paused, ...opts }) => dispatch =>
+  dispatch({ type: 'TRY_ADD_DAT', key, path, paused, ...opts })
 export const deleteDat = key => ({ type: 'DIALOGS_DELETE_OPEN', key })
 export const confirmDeleteDat = key => dispatch => {
-  const { dat } = dats[key]
-
-  if (dat.network) {
-    for (const con of dat.network.connections) {
-      con.removeAllListeners()
-    }
-  }
-  dat.stats.removeAllListeners()
-  clearInterval(dat.updateInterval)
-
-  dat.close()
-  delete dats[key]
-  storeOnDisk()
-  dispatch({ type: 'REMOVE_DAT', key })
+  dispatch({ type: 'REMOVE_DAT' })
   dispatch({ type: 'DIALOGS_DELETE_CLOSE' })
 }
 export const cancelDeleteDat = () => ({ type: 'DIALOGS_DELETE_CLOSE' })
-
-export const togglePause = ({ key, paused }) => dispatch => {
-  const { dat } = dats[key]
-  if (paused) {
-    joinNetwork(dat)(dispatch)
-  } else {
-    dat.leaveNetwork()
-  }
-  storeOnDisk()
-  if (paused) {
-    dispatch({ type: 'RESUME_DAT', key: key })
-  } else {
-    dispatch({ type: 'PAUSE_DAT', key: key })
-  }
-}
+export const togglePause = ({ key, paused }) => dispatch =>
+  dispatch({ type: 'TOGGLE_PAUSE', paused, key })
 
 export const inspectDat = key => dispatch => {
   dispatch({ type: 'INSPECT_DAT', key })
@@ -337,76 +77,16 @@ export const updateTemporaryTitleValue = title => ({
   title
 })
 
-export const updateTitle = (key, path, editValue) => async dispatch => {
-  const filePath = `${path}/dat.json`
-  const blob = await readFile(filePath)
-  const metadata = { ...JSON.parse(blob), title: editValue }
-  await writeFile(filePath, JSON.stringify(metadata))
-
+export const updateTitle = (key, path, editValue) => async dispatch =>
   dispatch({
     type: 'UPDATE_TITLE',
     key,
     editValue
   })
-}
 
 export const deactivateTitleEditing = () => ({
   type: 'DEACTIVATE_TITLE_EDITING'
 })
-
-export const loadFromDisk = () => async dispatch => {
-  try {
-    await mkdir(`${homedir()}/.dat-desktop`)
-  } catch (_) {}
-
-  let blob
-  try {
-    blob = await readFile(`${homedir()}/.dat-desktop/dats.json`, 'utf8')
-  } catch (_) {
-    return
-  }
-  const datOpts = JSON.parse(blob)
-
-  blob = {}
-  try {
-    blob = await readFile(`${homedir()}/.dat-desktop/paused.json`, 'utf8')
-  } catch (_) {}
-  const paused = JSON.parse(blob)
-
-  for (const key of Object.keys(datOpts)) {
-    const opts = JSON.parse(datOpts[key])
-    addDat({
-      key,
-      path: opts.dir,
-      paused: paused[key],
-      ...opts
-    })(dispatch)
-  }
-}
-
-const storeOnDisk = async () => {
-  const dir = `${homedir()}/.dat-desktop`
-  const datsState = Object.keys(dats).reduce(
-    (acc, key) => ({
-      ...acc,
-      [key]: JSON.stringify({
-        dir: dats[key].path,
-        opts: dats[key].opts
-      })
-    }),
-    {}
-  )
-  const pausedState = Object.keys(dats).reduce(
-    (acc, key) => ({
-      ...acc,
-      [key]: !dats[key].dat.network
-    }),
-    {}
-  )
-
-  await writeFile(`${dir}/dats.json`, JSON.stringify(datsState))
-  await writeFile(`${dir}/paused.json`, JSON.stringify(pausedState))
-}
 
 export const toggleMenu = visible => dispatch => {
   dispatch({ type: 'TOGGLE_MENU', visible })

--- a/app/components/button.js
+++ b/app/components/button.js
@@ -21,7 +21,7 @@ const BaseButton = styled.button`
 
 const HeaderButton = BaseButton.extend`
   color: var(--color-neutral-30);
-  height:2rem;
+  height: 2rem;
   :hover,
   :focus {
     color: var(--color-white);

--- a/app/components/dat-import.js
+++ b/app/components/dat-import.js
@@ -19,7 +19,7 @@ const Label = styled.label`
     width: 7.5rem;
     padding-right: 0.5rem;
     padding-left: 2rem;
-    border-radius:2px;
+    border-radius: 2px;
     border: 1px solid transparent;
     background-color: transparent;
     color: var(--color-neutral-30);

--- a/app/components/header.js
+++ b/app/components/header.js
@@ -29,38 +29,47 @@ const HideLayer = styled.div`
 
 const Header = ({ onShare, onMenu, onReport, menuVisible, version }) => {
   const toggleMenu = () => onMenu(!menuVisible)
-  return <Container>
-    { menuVisible && <HideLayer onClick={toggleMenu} /> }
-    <div className='fr relative'>
-      <DatImport />
-      <Button.Header
-        icon={<Icon name='create-new-dat' style={{ width: '1.2em' }} />}
-        className='b--transparent v-mid color-neutral-30 hover-color-white f7 f6-l'
-        onClick={onShare}
-      >
-        Share Folder
-      </Button.Header>
-      <Button.Header
-        icon={<Icon name='menu' style={{ width: '1.2em' }} />}
-        className='ml2 v-mid color-neutral-20 hover-color-white pointer'
-        onClick={toggleMenu}
-      >
-      </Button.Header>
-      { menuVisible &&
-        <div className="absolute right-0 br1 w5 pa3 bg-neutral" style={{ top: '3rem', zIndex: 6 }}>
-          <h3 className="f6 f5-l mb2">
-            Dat Desktop {version}
-          </h3>
-          <p className="f6 f5-l mb3">
-            Dat Desktop is a peer to peer sharing app built for humans by humans.
-          </p>
-          <p className="f6 f5-l">
-            <a onClick={onReport} href="#" className="color-neutral-50  hover-color-neutral-70">Report Bug</a>
-          </p>
-        </div>
-      }
-    </div>
-  </Container>
+  return (
+    <Container>
+      {menuVisible && <HideLayer onClick={toggleMenu} />}
+      <div className='fr relative'>
+        <DatImport />
+        <Button.Header
+          icon={<Icon name='create-new-dat' style={{ width: '1.2em' }} />}
+          className='b--transparent v-mid color-neutral-30 hover-color-white f7 f6-l'
+          onClick={onShare}
+        >
+          Share Folder
+        </Button.Header>
+        <Button.Header
+          icon={<Icon name='menu' style={{ width: '1.2em' }} />}
+          className='ml2 v-mid color-neutral-20 hover-color-white pointer'
+          onClick={toggleMenu}
+        />
+        {menuVisible && (
+          <div
+            className='absolute right-0 br1 w5 pa3 bg-neutral'
+            style={{ top: '3rem', zIndex: 6 }}
+          >
+            <h3 className='f6 f5-l mb2'>Dat Desktop {version}</h3>
+            <p className='f6 f5-l mb3'>
+              Dat Desktop is a peer to peer sharing app built for humans by
+              humans.
+            </p>
+            <p className='f6 f5-l'>
+              <a
+                onClick={onReport}
+                href='#'
+                className='color-neutral-50  hover-color-neutral-70'
+              >
+                Report Bug
+              </a>
+            </p>
+          </div>
+        )}
+      </div>
+    </Container>
+  )
 }
 
 export default Header

--- a/app/components/status-bar.js
+++ b/app/components/status-bar.js
@@ -6,7 +6,7 @@ const Bar = styled.div`
   position: absolute;
   bottom: 0;
   width: 100%;
-  padding: .5rem 1rem .75rem;
+  padding: 0.5rem 1rem 0.75rem;
   background-color: var(--color-neutral-04);
   color: var(--color-neutral-60);
 `

--- a/app/components/status.js
+++ b/app/components/status.js
@@ -7,7 +7,7 @@ import bytes from 'prettier-bytes'
 const ProgressBar = styled.div`
   --progress-height: 0.5rem;
   --bar-height: var(--progress-height);
-  --counter-width: 3.0rem;
+  --counter-width: 3rem;
   --tile-width: 28px;
   --stripe-width: 5px;
   min-width: 8rem;

--- a/app/containers/header.js
+++ b/app/containers/header.js
@@ -10,8 +10,9 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   onShare: () => dispatch(createDat()),
-  onMenu: (visible) => dispatch(toggleMenu(visible)),
-  onReport: () => shell.openExternal('https://github.com/dat-land/dat-desktop/issues/')
+  onMenu: visible => dispatch(toggleMenu(visible)),
+  onReport: () =>
+    shell.openExternal('https://github.com/dat-land/dat-desktop/issues/')
 })
 
 const HeaderContainer = connect(mapStateToProps, mapDispatchToProps)(Header)

--- a/app/index.js
+++ b/app/index.js
@@ -5,15 +5,20 @@ import { render } from 'react-dom'
 import { Provider } from 'react-redux'
 import { createStore, applyMiddleware, compose } from 'redux'
 import datDesktopApp from './reducers'
-import { addDat, loadFromDisk } from './actions'
+import { addDat } from './actions'
 import App from './components/app'
 import logger from 'redux-logger'
 import thunk from 'redux-thunk'
 import { ipcRenderer as ipc } from 'electron'
+import DatMiddleware from './actions/dat-middleware'
+
+const datMiddleware = new DatMiddleware()
 
 const store = createStore(
   datDesktopApp,
-  compose(applyMiddleware(thunk, logger))
+  compose(
+    applyMiddleware(store => datMiddleware.middleware(store), thunk, logger)
+  )
 )
 
 render(
@@ -23,7 +28,7 @@ render(
   document.querySelector('div')
 )
 
-store.dispatch(loadFromDisk())
+datMiddleware.loadFromDisk()
 
 ipc.on('log', (_, str) => console.log(str))
 ipc.on('link', key => store.dispatch(addDat({ key })))

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -319,26 +319,16 @@ const redatApp = (state = defaultState, action) => {
           }
         }
       }
-    case 'PAUSE_DAT':
+    case 'TOGGLE_PAUSE':
+      const dat = state.dats[action.key]
       return {
         ...state,
         dats: {
           ...state.dats,
           [action.key]: {
-            ...state.dats[action.key],
-            paused: true,
-            peers: 0
-          }
-        }
-      }
-    case 'RESUME_DAT':
-      return {
-        ...state,
-        dats: {
-          ...state.dats,
-          [action.key]: {
-            ...state.dats[action.key],
-            paused: false
+            ...dat,
+            paused: !action.paused,
+            peers: !action.paused ? 0 : dat.peers
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5999,6 +5999,14 @@
         }
       }
     },
+    "mkdirp-promise": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dat-node": "^3.5.7",
     "electron-default-menu": "^1.0.1",
     "mirror-folder": "^2.1.1",
+    "mkdirp-promise": "^5.0.1",
     "ms": "^2.1.1",
     "polished": "^1.9.2",
     "prettier-bytes": "^1.0.4",


### PR DESCRIPTION
In a future PR I need to specify the home director for DAT operations. This PR also moves globals of actions (`dats`) from [a global variable](https://github.com/dat-land/dat-desktop/blob/af328a1d5ca2a3dcfcfc3959d3bc42832accf2b0/app/actions/index.js#L12) into a [class/instance system](https://github.com/dat-land/dat-desktop/blob/a5e2aa180e689a34789bbce91ae94af7afa915f9/app/actions/dat-middleware.js#L19). This also turns the [`LOAD_ACTION`](https://github.com/dat-land/dat-desktop) - (_which wasn't a real action_) in [`./app/index.js`](https://github.com/dat-land/dat-desktop/blob/af328a1d5ca2a3dcfcfc3959d3bc42832accf2b0/app/index.js#L26) into an [`regular operation`](https://github.com/dat-land/dat-desktop/blob/a5e2aa180e689a34789bbce91ae94af7afa915f9/app/index.js#L31).

It also theoretically allows multiple react windows interacting with the same middleware through [a very basic listener system](https://github.com/dat-land/dat-desktop/blob/a5e2aa180e689a34789bbce91ae94af7afa915f9/app/actions/dat-middleware.js#L60-L62).

It furthermore adds the [success/error concept](https://github.com/dat-land/dat-desktop/blob/add/download-middleware/app/actions/dat-middleware.js#L36-L42) to all middleware operations. My thinking is that there should be a `{ACTION}`-action before `{ACTION}_SUCCESS` or `{ACTION}_ERROR` if an error/success happened during the operation. This would allow to show errors if errors occur and progress displays in the time between an action starts and an action finishes.

