### PR TITLE
Fixed header drag & drop

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,6 +10,7 @@ import App from './components/app'
 import logger from 'redux-logger'
 import thunk from 'redux-thunk'
 import { ipcRenderer as ipc } from 'electron'
+import drag from 'electron-drag'
 
 const store = createStore(
   datDesktopApp,
@@ -22,6 +23,8 @@ render(
   </Provider>,
   document.querySelector('div')
 )
+
+drag('header')
 
 store.dispatch(loadFromDisk())
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,6 +2112,12 @@
       "integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "optional": true
+    },
     "bitfield-rle": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bitfield-rle/-/bitfield-rle-2.1.0.tgz",
@@ -4729,6 +4735,11 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
+    "dombo": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/dombo/-/dombo-3.2.0.tgz",
+      "integrity": "sha1-C+GKjxbegncHabulPf2tM9fQ3mg="
+    },
     "domelementtype": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
@@ -5100,6 +5111,16 @@
             "pinkie-promise": "^2.0.0"
           }
         }
+      }
+    },
+    "electron-drag": {
+      "version": "github:martinheidegger/electron-drag#f432d168f0a4f7f53aa9272793dd4c6793072ea0",
+      "from": "github:martinheidegger/electron-drag#f432d168f0a4f7f53aa9272793dd4c6793072ea0",
+      "requires": {
+        "dombo": "^3.2.0",
+        "osx-mouse": "^1.2.0",
+        "try-require": "^1.2.1",
+        "win-mouse": "^1.1.0"
       }
     },
     "electron-osx-sign": {
@@ -10376,6 +10397,16 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "osx-mouse": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/osx-mouse/-/osx-mouse-1.2.1.tgz",
+      "integrity": "sha1-zN1Nvv0yk8vE+3cwHqsTfL4ayFw=",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.2.0"
+      }
+    },
     "p-cancelable": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
@@ -13577,6 +13608,11 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "try-require": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/try-require/-/try-require-1.2.1.tgz",
+      "integrity": "sha1-NEiaLKwMCcHMEO2RugEVlNQzO+I="
+    },
     "tslib": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
@@ -14846,6 +14882,16 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "win-mouse": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/win-mouse/-/win-mouse-1.1.2.tgz",
+      "integrity": "sha1-+D44vn5+Lp56KGFW4nZwYPkxJb0=",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.0.9"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "dat-icons": "^2.5.2",
     "dat-node": "^3.5.8",
     "electron-default-menu": "^1.0.1",
+    "electron-drag": "github:martinheidegger/electron-drag#f432d168f0a4f7f53aa9272793dd4c6793072ea0",
     "mirror-folder": "^3.0.0",
     "ms": "^2.1.1",
     "polished": "^1.9.2",


### PR DESCRIPTION
When developer-tools are active in electron, drag&drop stops working (See: https://github.com/electron/electron/issues/3647) This PR uses an [improved version](https://github.com/martinheidegger/electron-drag) of [`electron-drag`](https://github.com/kapetan/electron-drag) to enable drag & drop.