### PR TITLE
Warning about different Node Version

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,20 @@ const path = require('path')
 const isDev = process.env.NODE_ENV === 'development'
 const { Writable } = require('stream')
 
+if (typeof process.env.NODE_V === 'string' && process.env.NODE_V !== process.version) {
+  console.error(`
+    WARNING:
+      You are using a different version of Node than is used in this electron release!
+      - Used Version: ${process.env.NODE_V}
+      - Electron's Node Version: ${process.version}
+    
+      We recommend running:
+      
+      $ nvm install ${process.version}; npm rebuild;
+
+    `)
+}
+
 const menu = defaultMenu(app, shell)
 menu[menu.length - 1].submenu.push({
   label: 'Doctor',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Dat Desktop App",
   "author": "Dat Team <community@datproject.org>",
   "scripts": {
-    "start": "cross-env NODE_ENV=development electron .",
+    "start": "cross-env NODE_V=\"$(node -v)\" NODE_ENV=development electron .",
     "pretest": "npm run lint",
     "test": "npm run test:unit",
     "test:unit": "cross-env NODE_ENV=test babel-tape-runner -r ./unit-tests/_helpers/*.js unit-tests/*.js",


### PR DESCRIPTION
Backstory: Just tried (for far too long) to find out why osx-mouse isn't running at my colleagues computer. It turns out that the node/npm version that built the module was a different one than what was bundled with Electron.

This PR adds a warning when you start electron that the version used in the command line is different from the version bundled with electron. This way any team member that might run into the same issue will be warned as well.