### PR TITLE
Extracted screens into constants

### DIFF
--- a/app/consts/screen.js
+++ b/app/consts/screen.js
@@ -1,0 +1,11 @@
+export const INTRO = 'intro'
+export const DATS = 'dats'
+export const DOWNLOAD = 'download'
+export const INSPECT = 'inspect'
+
+export default {
+    INTRO,
+    DATS,
+    DOWNLOAD,
+    INSPECT
+}

--- a/app/containers/download.js
+++ b/app/containers/download.js
@@ -1,5 +1,6 @@
 'use strict'
 
+import SCREEN from '../consts/screen'
 import Download from '../components/download'
 import {
   addDat,
@@ -10,7 +11,7 @@ import {
 import { connect } from 'react-redux'
 
 const mapStateToProps = state => ({
-  show: state.screen === 'download',
+  show: state.screen === SCREEN.DOWNLOAD,
   dat: state.dats[state.downloadDatKey]
 })
 

--- a/app/containers/intro.js
+++ b/app/containers/intro.js
@@ -1,11 +1,12 @@
 'use strict'
 
+import SCREEN from '../consts/screen'
 import { connect } from 'react-redux'
 import IntroScreen from '../components/intro'
 import { openHomepage, nextIntro, hideIntro } from '../actions'
 
 const mapStateToProps = state => ({
-  show: state.screen === 'intro',
+  show: state.screen === SCREEN.INTRO,
   screen: state.intro.screen
 })
 

--- a/app/containers/status-bar.js
+++ b/app/containers/status-bar.js
@@ -1,12 +1,13 @@
 'use strict'
 
+import SCREEN from '../consts/screen'
 import StatusBar from '../components/status-bar'
 import { connect } from 'react-redux'
 
 const mapStateToProps = state => ({
   up: state.speed.up,
   down: state.speed.down,
-  show: state.screen === 'dats'
+  show: state.screen === SCREEN.DATS
 })
 
 const mapDispatchToProps = dispatch => ({})

--- a/app/containers/table.js
+++ b/app/containers/table.js
@@ -1,11 +1,12 @@
 'use strict'
 
+import SCREEN from '../consts/screen'
 import Table from '../components/table'
 import { connect } from 'react-redux'
 
 const mapStateToProps = state => ({
   dats: state.dats,
-  show: state.screen === 'dats'
+  show: state.screen === SCREEN.DATS
 })
 
 const TableContainer = connect(mapStateToProps, null)(Table)

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,8 +1,10 @@
 'use strict'
 
+import SCREEN from '../consts/screen'
+
 const defaultState = {
   dats: {},
-  screen: 'intro',
+  screen: SCREEN.INTRO,
   dialogs: {
     link: {
       link: null,
@@ -42,18 +44,18 @@ const redatApp = (state = defaultState, action) => {
       document.title = 'Dat Desktop'
       return {
         ...state,
-        screen: 'dats'
+        screen: SCREEN.DATS
       }
     case 'SHOW_DOWNLOAD_SCREEN':
       return {
         ...state,
-        screen: 'download',
+        screen: SCREEN.DOWNLOAD,
         downloadDatKey: action.key
       }
     case 'HIDE_DOWNLOAD_SCREEN':
       return {
         ...state,
-        screen: 'dats',
+        screen: SCREEN.DATS,
         downloadDatKey: null
       }
     case 'CHANGE_DOWNLOAD_PATH':
@@ -86,7 +88,7 @@ const redatApp = (state = defaultState, action) => {
             }
           }
         },
-        screen: 'dats'
+        screen: SCREEN.DATS
       }
     case 'ADD_DAT_ERROR':
     case 'WRITE_METADATA_ERROR':
@@ -118,7 +120,7 @@ const redatApp = (state = defaultState, action) => {
     case 'INSPECT_DAT':
       return {
         ...state,
-        screen: 'inspect',
+        screen: SCREEN.INSPECT,
         inspect: {
           key: action.key
         }
@@ -126,7 +128,7 @@ const redatApp = (state = defaultState, action) => {
     case 'INSPECT_DAT_CLOSE':
       return {
         ...state,
-        screen: 'dats'
+        screen: SCREEN.DATS
       }
     case 'DAT_FILES':
       return {
@@ -286,7 +288,7 @@ const redatApp = (state = defaultState, action) => {
     case 'DIALOGS_DELETE_CLOSE':
       return {
         ...state,
-        screen: 'dats',
+        screen: SCREEN.DATS,
         dialogs: {
           ...state.dialogs,
           delete: {


### PR DESCRIPTION
The screen-identifiers are strings. By extracting all existing identifiers into a constant-module we can now have code-suggestions in an IDE (ms vscode for example)

