### PR TITLE
Fix: dev tools at minimum window width

### DIFF
--- a/app/components/status-bar.js
+++ b/app/components/status-bar.js
@@ -3,9 +3,10 @@ import styled from 'styled-components'
 import bytes from 'prettier-bytes'
 
 const Bar = styled.div`
-  position: absolute;
+  position: fixed;
+  left:0;
   bottom: 0;
-  width: 100%;
+  width: 100vw;
   padding: 0.5rem 1rem 0.75rem;
   background-color: var(--color-neutral-04);
   color: var(--color-neutral-60);

--- a/static/base.css
+++ b/static/base.css
@@ -26,9 +26,14 @@ time, mark, audio, video {
   border: 0;
 }
 
+html {
+  overflow: auto;
+}
+
 body {
   line-height: 1.5;
   overflow: hidden;
+  min-width: 800px;
 }
 
 main {


### PR DESCRIPTION
Before this PR the window couldn't be used properly with the developer tools open. This means that styling test were hard to do.
After this pull request, scrolling should be possible even if the window
is less than the minimum width.