### PR TITLE
Fixed deprecated syntax in StyledComponent.

### DIFF
--- a/app/components/button.js
+++ b/app/components/button.js
@@ -29,7 +29,7 @@ const BaseButton = styled.button.attrs({
   }
 `
 
-const HeaderButton = BaseButton.extend`
+const HeaderButton = styled(BaseButton)`
   color: var(--color-neutral-30);
   height: 2rem;
   :hover,
@@ -38,7 +38,7 @@ const HeaderButton = BaseButton.extend`
   }
 `
 
-var PlainButton = BaseButton.extend`
+var PlainButton = styled(BaseButton)`
   padding: 0.5rem 0.75rem;
   font-size: 0.75rem;
   background-color: transparent;
@@ -49,7 +49,7 @@ var PlainButton = BaseButton.extend`
   }
 `
 
-var GreenButton = BaseButton.extend`
+var GreenButton = styled(BaseButton)`
   padding: 0.5rem 0.75rem;
   font-size: 0.75rem;
   background-color: var(--color-green);
@@ -61,7 +61,7 @@ var GreenButton = BaseButton.extend`
   }
 `
 
-var RedButton = BaseButton.extend`
+var RedButton = styled(BaseButton)`
   padding: 0.5rem 0.75rem;
   font-size: 0.75rem;
   background-color: var(--color-red);


### PR DESCRIPTION
The master branch was giving off a warning about the "extend" API. This replaces it with the new "styled" API.

For reference here is the original error:

```
ThemeProvider.js:28 Warning: The "extend" API will be removed in the upcoming v4.0 release. Use styled(StyledComponent) instead. You can find more information here: https://github.com/styled-components/styled-components/issues/1546
(anonymous) @ ThemeProvider.js:28
```