### PR TITLE
Corrected travis-badge location

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <div align="center">
   <!-- Build Status -->
-  <a href="https://travis-ci.org/datproject/dat-desktop">
-    <img src="https://img.shields.io/travis/datproject/dat-desktop/master.svg?style=flat-square"
+  <a href="https://travis-ci.org/dat-land/dat-desktop">
+    <img src="https://img.shields.io/travis/dat-land/dat-desktop/master.svg?style=flat-square"
       alt="Build Status" />
   </a>
   <!-- Standard -->


### PR DESCRIPTION
The travis badge was still pointing towards datproject.