### PR TITLE
Fix: Press "cancel" on download-preview-screen continues to walk dat.

### DIFF
--- a/app/actions/dat-middleware.js
+++ b/app/actions/dat-middleware.js
@@ -290,9 +290,7 @@ export default class DatMiddleware {
     })
   }
 
-  async cancelDownloadDat (key) {
-    key = encode(key)
-
+  async cancelDownloadDat ({ key }) {
     this.removeDatInternally(key)
   }
 
@@ -305,6 +303,7 @@ export default class DatMiddleware {
 
   removeDatInternally (key) {
     const { dat } = this.dats[key]
+    if (!dat) return // maybe was deleted
     delete this.dats[key]
     if (dat.mirrorProgress) {
       dat.mirrorProgress.destroy()

--- a/app/components/table-row.js
+++ b/app/components/table-row.js
@@ -145,6 +145,7 @@ const Row = ({
   updateTitle
 }) => {
   const { writable, metadata, key } = dat
+  if (!metadata) return null
   const { title } = metadata
   const placeholderTitle = `#${key}`
   return (


### PR DESCRIPTION
Even if you cancel the download of a DAT, the DAT is continuously downloaded by DAT-desktop.

The reason for this is that in the middleware on the `CANCEL_DAT` action it receives an object with the `key` property:

https://github.com/dat-land/dat-desktop/blob/e458a4a59a2a44a33c588deb8d23b6a8a5bd0708/app/actions/index.js#L38-L39

https://github.com/dat-land/dat-desktop/blob/e458a4a59a2a44a33c588deb8d23b6a8a5bd0708/app/actions/dat-middleware.js#L29

... but it is treated as string when canceling the DAT ...

https://github.com/dat-land/dat-desktop/blob/e458a4a59a2a44a33c588deb8d23b6a8a5bd0708/app/actions/dat-middleware.js#L293-L294

This PR fixes this by assuming the `{key}` property for every command.