### PR TITLE
Simplified Readme and Markdown syntax check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,14 @@
-<h1 align="center">Dat Desktop</h1>
+# Dat Desktop
 
-<div align="center">
-  <strong>Peer to peer data sharing app built for humans.</strong>
-</div>
+**Peer to peer data sharing app built for humans.**
 
-<br />
-
-<div align="center">
-  <!-- Build Status -->
-  <a href="https://travis-ci.org/dat-land/dat-desktop">
-    <img src="https://img.shields.io/travis/dat-land/dat-desktop/master.svg?style=flat-square"
-      alt="Build Status" />
-  </a>
-  <!-- Standard -->
-  <a href="https://standardjs.com">
-    <img src="https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square"
-      alt="Standard" />
-  </a>
-</div>
+[!["Build Status"](https://img.shields.io/travis/dat-land/dat-desktop/master.svg?style=flat-square)](https://travis-ci.org/dat-land/dat-desktop) 
+[!["Standard](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://standardjs.com)
 
 ![screenshot](assets/screenshot.png)
 
 ## Table of Content
+
 - [Download](#download)
 - [Commands](#commands)
 - [FAQ](#faq)
@@ -29,30 +16,37 @@
 
 ## Download
 
-To run the app locally check out our [download
-guide](https://datproject.org/install) or install directly from the command
-line using [Homebrew Cask](https://caskroom.github.io). Currently only MacOS is
-supported.
+_Dat_ needs to be installed first. To run the app locally check out our [download
+guide](https://datproject.org/install) or install directly from the command line:
 
 ```sh
-$ brew update && brew cask install dat
+npm install -g dat
 ```
 
 ## Commands
 
-```bash
-$ npm install             # install dependencies
-$ npm start               # start the application
-$ npm run dist            # compile the app into an ASAR file to release
-$ npm start --data=<dir>  # change the path for new dat archives (default ~/Downloads/dat)
-$ npm start --db=<dir>    # change the path for users settings (default ~/.dat-desktop)
+To run _Dat Desktop_ in development mode:
+
+```sh
+npm install             # install dependencies
+npm run start           # start the application
+```
+
+To create binary packages run:
+
+```sh
+npm install             # install dependencies
+npm run dist :os        # compile the app into an binary package
 ```
 
 ## FAQ
 
-### How can I speed up downloading Electron?
-If you’re not in Europe or the US, you might want to use a different mirror for `electron`.
-You can set the `ELECTRON_MIRROR` variable to point to a different provider:
+### How to speed up downloading Electron
+
+If you’re not in Europe or the US, you might want to use a different mirror for 
+`electron`. You can set the `ELECTRON_MIRROR` variable to point to a different 
+provider:
+
 ```sh
 # Europe / US
 $ npm install
@@ -61,10 +55,12 @@ $ npm install
 $ ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/" npm install
 ```
 
-## License
-MIT
+## Licenses
 
-## Font Attribution & License
+[MIT License](https://github.com/dat-land/dat-desktop/blob/master/LICENSE)
+
+### Font Attribution & License
+
 SourceSansPro-Regular.ttf: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries. [SIL Open Font License, 1.1](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL)
 
 SourceCodePro-Regular.ttf: Copyright 2010, 2012 Adobe Systems Incorporated. All Rights Reserved. [SIL Open Font License, 1.1](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To run _Dat Desktop_ in development mode:
 
 ```sh
 npm install             # install dependencies
-npm run start           # start the application
+npm start               # start the application
 ```
 
 To create binary packages run:
@@ -57,7 +57,7 @@ $ ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/" npm install
 
 ## Licenses
 
-[MIT License](https://github.com/dat-land/dat-desktop/blob/master/LICENSE)
+[MIT License](./LICENSE)
 
 ### Font Attribution & License
 


### PR DESCRIPTION
I cleaned up the Readme file and removed outdated (and wrong) content. 

The first paragraphs had been aligned, which requires to use HTML content in Markdown, which I would like to avoid, if possible. I prefer to use default styling.