### PR TITLE
Removing drag-and-drop as it is incompatible with electron 3

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,7 +10,6 @@ import App from './components/app'
 import logger from 'redux-logger'
 import thunk from 'redux-thunk'
 import { ipcRenderer as ipc, remote } from 'electron'
-import drag from 'electron-drag'
 import DatMiddleware from './actions/dat-middleware'
 import minimist from 'minimist'
 import path from 'path'
@@ -51,7 +50,6 @@ datMiddleware
       </Provider>,
       document.querySelector('div')
     )
-    drag('header')
   })
   .catch(err => {
     console.log(err.stack || err)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "dat-icons": "^2.5.2",
     "dat-node": "^3.5.8",
     "electron-default-menu": "^1.0.1",
-    "electron-drag": "github:martinheidegger/electron-drag#f432d168f0a4f7f53aa9272793dd4c6793072ea0",
     "minimist": "^1.2.0",
     "mirror-folder": "^3.0.0",
     "mkdirp-promise": "^5.0.1",


### PR DESCRIPTION
Node 10.2 has a gyp problem which lead to `osx-mouse` not compiling properly: Effectively `electron-drag` has become not-supported. But it seems like dragging the header does work without it as well?!