### PR TITLE
Style improvements: file list

### DIFF
--- a/app/components/file-list.js
+++ b/app/components/file-list.js
@@ -4,52 +4,41 @@ import React from 'react'
 import styled from 'styled-components'
 import bytes from 'prettier-bytes'
 
-const FileListContainer = styled.div`
-  :host {
-    min-height: 5rem;
-  }
-`
-
 const FileListTable = styled.table`
-  :host {
-    td {
-      padding: 0.25rem 0.5rem;
-    }
-    tr:odd td {
-      background-color: var(--color-neutral-04);
-    }
+  width: 100%;
+  border-collapse: collapse;
+  tr:odd td {
+    background-color: var(--color-neutral-04);
+  }
+  td {
+    border: 0;
+  }
+  td:last-child {
+    width: 4rem;
+    text-align: right;
   }
 `
 
-const List = ({ dat }) => (
-  <FileListContainer>
-    {dat && dat.files && dat.files.length ? (
-      <FileListTable className='w-100 f7 f6-l '>
-        <tbody>
-          {dat.files.map(file => {
-            const size =
-              Number(file.size) === file.size && file.isFile
-                ? bytes(file.size)
-                : ''
-            return (
-              <tr key={file.path}>
-                <td className='truncate mw5'>{file.path}</td>
-                <td>{size}</td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </FileListTable>
-    ) : (
-      <div className='f7 f6-l pa2'>N/A</div>
-    )}
-  </FileListContainer>
-)
-
-const FileList = ({ dat }) => (
-  <FileListContainer className='flex-auto bg-white mb2 mw6'>
-    <List dat={dat} />
-  </FileListContainer>
-)
+const FileList = ({ dat, fallback = null }) => {
+  if (!dat || !dat.files || !dat.files.length) return fallback
+  return (
+    <FileListTable className='w-100 f7 f6-l'>
+      <tbody>
+        {dat.files.map(file => {
+          const size =
+            Number(file.size) === file.size && file.isFile
+              ? bytes(file.size)
+              : ''
+          return (
+            <tr key={file.path}>
+              <td className='truncate'>{file.path}</td>
+              <td>{size}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </FileListTable>
+  )
+}
 
 export default FileList

--- a/app/components/file-list.js
+++ b/app/components/file-list.js
@@ -7,11 +7,15 @@ import bytes from 'prettier-bytes'
 const FileListTable = styled.table`
   width: 100%;
   border-collapse: collapse;
-  tr:odd td {
-    background-color: var(--color-neutral-04);
+  tr:nth-child(odd) td {
+    background-color: var(--color-white);
+  }
+  tr:nth-child(even) td {
+    background-color: var(--color-neutral-10);
   }
   td {
     border: 0;
+    padding: 0.25rem;
   }
   td:last-child {
     width: 4rem;

--- a/app/components/inspect.js
+++ b/app/components/inspect.js
@@ -82,22 +82,22 @@ const Inspect = ({
         <h2 className='f5 normal truncate pr3 w-90'>{title}</h2>
       </DetailHeader>
       <div className='flex-auto pa3 pl5 bg-neutral-04 overflow-y-auto'>
-        <Row label='Link' data-test='key'>
+        <Row label='Link:' data-test='key'>
           {toStr(dat.key)}
         </Row>
-        <Row label='Size' data-test='size'>
+        <Row label='Size:' data-test='size'>
           {size}
         </Row>
-        <Row label='Peers' data-test='peers'>
+        <Row label='Peers:' data-test='peers'>
           {peers}
         </Row>
-        <Row label='Author' data-test='author'>
+        <Row label='Author:' data-test='author'>
           {author}
         </Row>
-        <Row label='Description' data-test='description'>
+        <Row label='Description:' data-test='description'>
           {description}
         </Row>
-        <Row label='Download to' className='flex bg-white' data-test='path'>
+        <Row label='Download to:' className='flex bg-white' data-test='path'>
           <pre
             className='flex-auto f7 f6-l'
             style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
@@ -108,7 +108,7 @@ const Inspect = ({
             CHANGE...
           </TextButton>
         </Row>
-        <Row label='Files' style={{padding: 0}}>
+        <Row label='Files:' style={{padding: 0}}>
           <FileList
             dat={dat}
             fallback={<div className='f7 f6-l pa2'>N/A</div>}

--- a/app/components/inspect.js
+++ b/app/components/inspect.js
@@ -32,6 +32,7 @@ const Label = styled.div`
   color: var(--color-neutral-60);
   text-align: right;
   padding: 0.25rem;
+  padding-right: 0.5rem;
 `
 
 const Column = styled.div`
@@ -81,22 +82,22 @@ const Inspect = ({
         <h2 className='f5 normal truncate pr3 w-90'>{title}</h2>
       </DetailHeader>
       <div className='flex-auto pa3 pl5 bg-neutral-04 overflow-y-auto'>
-        <Row label='Link:' data-test='key'>
+        <Row label='Link' data-test='key'>
           {toStr(dat.key)}
         </Row>
-        <Row label='Size:' data-test='size'>
+        <Row label='Size' data-test='size'>
           {size}
         </Row>
-        <Row label='Peers:' data-test='peers'>
+        <Row label='Peers' data-test='peers'>
           {peers}
         </Row>
-        <Row label='Author:' data-test='author'>
+        <Row label='Author' data-test='author'>
           {author}
         </Row>
-        <Row label='Description:' data-test='description'>
+        <Row label='Description' data-test='description'>
           {description}
         </Row>
-        <Row label='Download to:' className='flex bg-white' data-test='path'>
+        <Row label='Download to' className='flex bg-white' data-test='path'>
           <pre
             className='flex-auto f7 f6-l'
             style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
@@ -107,7 +108,7 @@ const Inspect = ({
             CHANGE...
           </TextButton>
         </Row>
-        <Row label='Files:'>
+        <Row label='Files' style={{padding: 0}}>
           <FileList
             dat={dat}
             fallback={<div className='f7 f6-l pa2'>N/A</div>}


### PR DESCRIPTION
This PR cleans a few style issues in the file list:

1. It puts the size at the right sight of the line.

    Before: ![line-right-before](https://user-images.githubusercontent.com/914122/49348823-141d1d80-f6eb-11e8-816e-371ffd15c88a.png)
    After: ![line-right-after](https://user-images.githubusercontent.com/914122/49348827-17b0a480-f6eb-11e8-920f-14b647e569e7.png)

2. It fixes the `odd` line style to actually work ;). It also changes the contrast from `--color-neutral-04` to `--color-neutral-10` in order to for the lines to be better distinguishable from the background.

    | Before | Before - fixed | After |
    |---|---|---|
    | ![lines-before](https://user-images.githubusercontent.com/914122/49348932-8aba1b00-f6eb-11e8-80d0-a054a6ead44a.png) | <img alt="screen shot 2018-12-03 at 11 13 48" src="https://user-images.githubusercontent.com/914122/49349129-8b9f7c80-f6ec-11e8-9b88-98294bea6d3f.png"> | ![lines-after](https://user-images.githubusercontent.com/914122/49348939-90176580-f6eb-11e8-9dcc-937867a4217e.png) |

3. It removes the colon's `:` of the file titles 

    | Before | After |
    |---|---|
    | ![titles-before](https://user-images.githubusercontent.com/914122/49349246-2435fc80-f6ed-11e8-850d-5c646212746b.png) | ![colon-after](https://user-images.githubusercontent.com/914122/49349261-2ef09180-f6ed-11e8-802e-7b0ed8d6802f.png) |



