### PR TITLE
fixed: focussing on title-edit

### DIFF
--- a/app/components/title-field.js
+++ b/app/components/title-field.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import ReactDOM from 'react-dom'
 import styled from 'styled-components'
 import Icon from './icon'
 import { Plain as PlainButton, Green as GreenButton } from './button'
@@ -35,32 +36,38 @@ const EditableFieldWrapper = styled.div`
   }
 `
 
-const InputField = styled.input`
+const InputFieldStyle = styled.input`
   :focus {
     outline: none;
   }
 `
 
+class InputField extends Component {
+  componentDidMount () {
+    const input = ReactDOM.findDOMNode(this)
+    input.focus()
+    input.select()
+  }
+  render () {
+    return <InputFieldStyle {...this.props} />
+  }
+}
+
 class TitleField extends Component {
-  startEditing () {
-    this.setState({ editing: true })
+  constructor (props) {
+    super(props)
+    this.titleInput = React.createRef()
   }
 
   onclick (ev) {
     ev.stopPropagation()
     ev.preventDefault()
-    this.startEditing()
-
-    // setTimeout? Because ref on input is set asynchronously, and later. So we can't do focus, select on it until ref is set
-    setTimeout(() => {
-      this.titleInput.focus()
-      this.titleInput.select()
-    }, 0)
+    this.setState({ editing: true })
   }
 
   commit () {
     const oldValue = this.props.value
-    const newValue = this.titleInput.value
+    const newValue = ReactDOM.findDOMNode(this.titleInput.current).value
     if (oldValue !== newValue) {
       this.props.onChange(newValue)
     }
@@ -108,14 +115,12 @@ class TitleField extends Component {
               className='bn f6 pl1 normal w-100'
               defaultValue={value}
               onKeyUp={ev => this.handleKeyup(ev)}
-              innerRef={input => {
-                this.titleInput = input
-              }}
+              ref={this.titleInput}
             />
-            {!modified ? (
-              <PlainButton onClick={() => this.commit()}>Save</PlainButton>
-            ) : (
+            {modified ? (
               <GreenButton onClick={() => this.commit()}>Save</GreenButton>
+            ) : (
+              <PlainButton onClick={() => this.cancel()}>Save</PlainButton>
             )}
           </EditableFieldWrapper>
         </div>

--- a/app/containers/drag-drop.js
+++ b/app/containers/drag-drop.js
@@ -34,10 +34,14 @@ const DropIcon = styled(Icon)`
   color: white;
 `
 
-const DragDropContainer = connect(mapStateToProps, mapDispatchToProps)(function(props){
-  return <DropFrame {...props}>
-    <DropIcon name='create-new-dat' />
-  </DropFrame>
+const DragDropContainer = connect(mapStateToProps, mapDispatchToProps)(function (
+  props
+) {
+  return (
+    <DropFrame {...props}>
+      <DropIcon name='create-new-dat' />
+    </DropFrame>
+  )
 })
 
 export default DragDropContainer


### PR DESCRIPTION
Title that were editable need to be clicked before the user can edit text.

![a25935b8e747eadd0d7662f79279e08e](https://user-images.githubusercontent.com/914122/48885764-d3acdc80-ee6c-11e8-945b-4adb98c6a313.gif)

This problem seems to have been caused by the update to styled-components v4

But even after a save: the title isn't stored because of https://github.com/dat-land/dat-desktop/pull/602/files#diff-84f92d50bee815f7173b3515a7313e7fL63

This PR fixes the behavior: Now the users can immediately change the title:

![3de9446aef7999e54314198bf1bc2e5b](https://user-images.githubusercontent.com/914122/48885853-21294980-ee6d-11e8-92be-68c88931a65d.gif)
