### PR TITLE
refactoring: moving "defaultState" moved to consts.

### DIFF
--- a/app/consts/state.js
+++ b/app/consts/state.js
@@ -2,7 +2,6 @@
 
 import SCREEN from '../consts/screen'
 
-// immutable
 export default () => ({
   dats: {},
   screen: SCREEN.INTRO,

--- a/app/consts/state.js
+++ b/app/consts/state.js
@@ -2,7 +2,7 @@
 
 import SCREEN from '../consts/screen'
 
-export default () => ({
+export const generateDefaultState = () => ({
   dats: {},
   screen: SCREEN.INTRO,
   dialogs: {

--- a/app/consts/state.js
+++ b/app/consts/state.js
@@ -1,0 +1,33 @@
+'use strict'
+
+import SCREEN from '../consts/screen'
+
+// immutable
+export default () => ({
+  dats: {},
+  screen: SCREEN.INTRO,
+  dialogs: {
+    link: {
+      link: null,
+      copied: false
+    },
+    delete: {
+      dat: null
+    }
+  },
+  speed: {
+    up: 0,
+    down: 0
+  },
+  inspect: {
+    key: null
+  },
+  intro: {
+    screen: 1
+  },
+  version: require('../../package.json').version,
+  menu: {
+    visible: false
+  },
+  downloadDatKey: null
+})

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,37 +1,9 @@
 'use strict'
 
 import SCREEN from '../consts/screen'
+import generateDefaultState from '../consts/state'
 
-const defaultState = {
-  dats: {},
-  screen: SCREEN.INTRO,
-  dialogs: {
-    link: {
-      link: null,
-      copied: false
-    },
-    delete: {
-      dat: null
-    }
-  },
-  speed: {
-    up: 0,
-    down: 0
-  },
-  inspect: {
-    key: null
-  },
-  intro: {
-    screen: 1
-  },
-  version: require('../../package.json').version,
-  menu: {
-    visible: false
-  },
-  downloadDatKey: null
-}
-
-const redatApp = (state = defaultState, action) => {
+const redatApp = (state = generateDefaultState(), action) => {
   switch (action.type) {
     case 'NEXT_INTRO':
       return {

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import SCREEN from '../consts/screen'
-import generateDefaultState from '../consts/state'
+import { generateDefaultState } from '../consts/state'
 
 const redatApp = (state = generateDefaultState(), action) => {
   switch (action.type) {


### PR DESCRIPTION
As part of a refactoring process where I would like to clean up the react state _(it is currently polluted with problematic data)_. I extracted the `defaultState` into its own file. As part of the process I also moved it into a function to prevent changing of the data by accident.