### PR TITLE
fix: deprecated syntax by current styled-components.

### DIFF
--- a/app/components/button.js
+++ b/app/components/button.js
@@ -3,7 +3,8 @@
 import React from 'react'
 import styled from 'styled-components'
 
-const BaseButton = styled.button.attrs({
+const BaseButton = styled.button.attrs(props => ({
+  ...props,
   onClick: props => {
     if (props.trigger) {
       return function (e) {
@@ -13,7 +14,7 @@ const BaseButton = styled.button.attrs({
     }
     return undefined
   }
-})`
+}))`
   text-transform: uppercase;
   letter-spacing: 0.025em;
   cursor: pointer;


### PR DESCRIPTION
styled-components deprecated the `.attr({})` syntax [in version 4.1.0](https://github.com/styled-components/styled-components/releases/tag/v4.1.0).
The recommended syntax is `.attr(props => ({}) )`.
PR is fixes the deprecation.