### PR TITLE
fix: update Electron, comment deprecated makeSingleInstance call

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,9 @@ if (typeof process.env.NODE_V === 'string' && process.env.NODE_V !== process.ver
       You are using a different version of Node than is used in this electron release!
       - Used Version: ${process.env.NODE_V}
       - Electron's Node Version: ${process.version}
-    
+
       We recommend running:
-      
+
       $ nvm install ${process.version}; npm rebuild;
 
     `)
@@ -91,13 +91,13 @@ app.on('window-all-closed', () => {
   app.quit()
 })
 
-const quit = app.makeSingleInstance(() => {
-  if (!win) return
-  if (win.isMinimized()) win.restore()
-  win.focus()
-})
-
-if (quit) app.quit()
+// const quit = app.makeSingleInstance(() => {
+//   if (!win) return
+//   if (win.isMinimized()) win.restore()
+//   win.focus()
+// })
+//
+// if (quit) app.quit()
 
 function watchAndReload () {
   let gaze

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cross-env": "^5.1.6",
     "del": "^3.0.0",
     "dependency-check": "^3.1.0",
-    "electron": "^3.0.8",
+    "electron": "^8.0.1",
     "electron-builder": "^20.31.2",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",


### PR DESCRIPTION
There may still be a bug I am not able to identify. Clicking "Get Started" has no effect.